### PR TITLE
fix: support chainable baseURL

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -357,37 +357,24 @@ With this router, you will get the following results:
 ### router.base()
 
 ```js
-router.base(baseURL?): Router
+router.base(path?): Router
 ```
 
 | Param | Type | Description |
 | --- | :-: | --- |
-| `baseURL` | string | The base URL of the new router. |
+| `path` | string | The path prefix of the new router. |
 
-This method creates a **new router** which will be mounted on the given `baseURL`. A base URL can be either an absolute or a relative path:
+This method creates a **new router** which will be mounted on the given `path`. You can regard the base paths as **a chain of path prefixes**.
 
 ```js
 // router.baseURL = 'http://localhost:3000'
 
-// when giving a relative path
 const apiRouter = router.base('/api');
 
 console.log(apiRouter === router); // false
 console.log(apiRouter.baseURL); // http://localhost:3000/api
 
-// when giving an absolute path
-const remoteRouter = router.base('https://a.com');
-
-console.log(remoteRouter.baseURL); // https://a.com
-```
-
-If the `baseURL` is provided with a relative path, it will be resolved against current mount path. You can regard the base URLs as a chain of path prefixes:
-
-```js
-const { router: apiRouter } = createServer('/api');
-
-console.log(apiRouter.baseURL); // http://localhost:3000/api
-
+// chain base paths
 const v1 = apiRouter.base('/v1');
 
 console.log(v1.baseURL); // http://localhost:3000/api/v1
@@ -397,11 +384,17 @@ v1.get('/users/:id', (req, res) => {
 });
 ```
 
-<p class="danger">The relative path here refers to the <strong>mount-path</strong> of your router. It should always start with a leading slash <code>'/'</code>, for example: <code>'/api'</code> is good but <code>'./api'</code> is bad.</p>
-
-When the base URL of a router is specified, all routes will base on the given `baseURL`:
+<p class="danger">Unlike the <a href="#createserver" jump-to-id="createserver"><code>createServer()</code></a> method, the <code>path</code> here should always be a relative one:</p>
 
 ```js
+router.base('/api'); // OK
+router.base('http://a.com/api'); // Error: not sharing same origin
+```
+
+When the base URL of a router is specified, all routes will base on it:
+
+```js
+const { router } = createServer();
 const apiRouter = router.base('/api');
 
 apiRouter.get('/greet', 'Hello new world');

--- a/docs/api.md
+++ b/docs/api.md
@@ -364,7 +364,7 @@ router.base(baseURL?): Router
 | --- | :-: | --- |
 | `baseURL` | string | The base URL of the new router. |
 
-This method creates a **new router** with the given `baseURL`. A base URL can be either an absolute or a relative path, the relative `baseURL` will be resolved to current origin.
+This method creates a **new router** which will be mounted on the given `baseURL`. A base URL can be either an absolute or a relative path:
 
 ```js
 // router.baseURL = 'http://localhost:3000'
@@ -380,6 +380,24 @@ const remoteRouter = router.base('https://a.com');
 
 console.log(remoteRouter.baseURL); // https://a.com
 ```
+
+If the `baseURL` is provided with a relative path, it will be resolved against current mount path. You can regard the base URLs as a chain of path prefixes:
+
+```js
+const { router: apiRouter } = createServer('/api');
+
+console.log(apiRouter.baseURL); // http://localhost:3000/api
+
+const v1 = apiRouter.base('/v1');
+
+console.log(v1.baseURL); // http://localhost:3000/api/v1
+
+v1.get('/users/:id', (req, res) => {
+  // matches /api/v1/users/:id
+});
+```
+
+<p class="danger">The relative path here refers to the <strong>mount-path</strong> of your router. It should always start with a leading slash <code>'/'</code>, for example: <code>'/api'</code> is good but <code>'./api'</code> is bad.</p>
 
 When the base URL of a router is specified, all routes will base on the given `baseURL`:
 

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -119,9 +119,18 @@ export class MockerRouter implements IMockerRouter {
 
   /**
    * Create a new router with the given baseURL,
-   * relative `baseURL` will be resolved to current origin
+   * the path will be resolved against current baseURL.
+   *
+   * Example:
+   *   router.base('/api');
+   *   router.base('http://a.com/api');
    */
   base(baseURL: string = this.baseURL): MockerRouter {
+    // resolve relative paths to current base path
+    if (baseURL[0] === '/') {
+      baseURL = this._basePath + baseURL;
+    }
+
     const url = new URL(baseURL, this._origin);
 
     return new MockerRouter(url.href);

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -118,20 +118,21 @@ export class MockerRouter implements IMockerRouter {
   }
 
   /**
-   * Create a new router with the given baseURL,
+   * Create a new router with the given path,
    * the path will be resolved against current baseURL.
-   *
-   * Example:
-   *   router.base('/api');
-   *   router.base('http://a.com/api');
    */
-  base(baseURL: string = this.baseURL): MockerRouter {
+  base(path: string = this.baseURL): MockerRouter {
     // resolve relative paths to current base path
-    if (baseURL[0] === '/') {
-      baseURL = this._basePath + baseURL;
+    if (path[0] === '/') {
+      path = this._basePath + path;
     }
 
-    const url = new URL(baseURL, this._origin);
+    const url = new URL(path, this._origin);
+
+    if (url.origin !== this._origin) {
+      // tslint:disable-next-line max-line-length
+      throw new Error(`the given path (${path}) is not sharing the same origin with current baseURL (${this.baseURL})`);
+    }
 
     return new MockerRouter(url.href);
   }

--- a/test/spec/server/request/req.baseURL.ts
+++ b/test/spec/server/request/req.baseURL.ts
@@ -20,7 +20,7 @@ export default function() {
       });
     });
 
-    describe('with `router.base(relative)', () => {
+    describe('with `router.base(path)', () => {
       it('should equal to the given relative path', async () => {
         const baseURL = '/api/v1';
         const path = uniquePath();
@@ -34,23 +34,6 @@ export default function() {
         await sendRequest(baseURL + path);
 
         expect(request.baseURL).to.equal(new URL(baseURL, location.href).href);
-      });
-    });
-
-    describe('with `router.base(absolute)', () => {
-      it('should equal to the remote address', async () => {
-        const remote = 'https://a.com/api';
-        const path = uniquePath();
-        let request: any;
-
-        router.base(remote).get(path, (req, res) => {
-          request = req;
-          res.end();
-        });
-
-        await sendRequest(remote + path);
-
-        expect(request.baseURL).to.equal(remote);
       });
     });
   });

--- a/test/spec/server/response/res.forward.ts
+++ b/test/spec/server/response/res.forward.ts
@@ -29,7 +29,9 @@ export default function() {
       const baseURL = 'https://api.spotify.com';
       const requsetInfo = `${baseURL}/albums/3oTKl46yD2fsb1dtUYq6Nn`;
 
-      router.base(baseURL).get('/albums/:id', (req, res) => {
+      const { router } = createServer(baseURL);
+
+      router.get('/albums/:id', (req, res) => {
         res.forward(`${req.baseURL}/v1${req.path}`);
       });
 

--- a/test/spec/server/router/router.base.ts
+++ b/test/spec/server/router/router.base.ts
@@ -42,10 +42,15 @@ export default function() {
 
     describe('with a relative path', () => {
       it('should resolve to current origin', () => {
-        const origin = 'http://a.com';
-        const rr = router.base(origin);
+        const rr = router.base('/whatever');
 
-        expect(rr.base('/whatever').baseURL).to.equal(origin + '/whatever');
+        expect(rr.baseURL).to.equal(new URL('/whatever', location.href).href);
+      });
+
+      it('should resolve against current baseURL', () => {
+        const rr = router.base('/what').base('/ever');
+
+        expect(new URL(rr.baseURL).pathname).to.equal('/what/ever');
       });
     });
 
@@ -55,6 +60,12 @@ export default function() {
         const rr = router.base(baseURL);
 
         expect(rr.baseURL).to.equal(baseURL);
+      });
+
+      it('should resolve against current baseURL', () => {
+        const rr = router.base('http://a.com/api').base('/whatever');
+
+        expect(new URL(rr.baseURL).pathname).to.equal('/api/whatever');
       });
     });
   });

--- a/test/spec/server/router/router.base.ts
+++ b/test/spec/server/router/router.base.ts
@@ -11,9 +11,9 @@ export default function() {
 
   describe('router.base(undefined)', () => {
     it('should set to current baseURL when not given', () => {
-      const rr = router.base('http://a.com/api');
+      const rr = router.base();
 
-      expect(rr.base().baseURL).to.equal(rr.baseURL);
+      expect(rr.baseURL).to.equal(router.baseURL);
     });
   });
 
@@ -23,10 +23,9 @@ export default function() {
     });
 
     it('should strip the trailing slash', () => {
-      const baseURL = 'http://a.com/api/v1';
-      const rr = router.base(baseURL + '/');
+      const rr = router.base('/api/');
 
-      expect(rr.baseURL).to.equal(baseURL);
+      expect(rr.baseURL).to.equal(router.baseURL + '/api');
     });
 
     it('should match baseURL from begining', async () => {
@@ -55,17 +54,16 @@ export default function() {
     });
 
     describe('with an absolute path', () => {
-      it('should resolve to the given path', () => {
-        const baseURL = 'http://a.com/api';
-        const rr = router.base(baseURL);
+      it('should abort processing', () => {
+        let err: any;
 
-        expect(rr.baseURL).to.equal(baseURL);
-      });
+        try {
+          router.base('http://a.com');
+        } catch (e) {
+          err = e;
+        }
 
-      it('should resolve against current baseURL', () => {
-        const rr = router.base('http://a.com/api').base('/whatever');
-
-        expect(new URL(rr.baseURL).pathname).to.equal('/api/whatever');
+        expect(err).to.exist;
       });
     });
   });


### PR DESCRIPTION
## Description

An implement of issue #22, which adopts express-style mount-paths. This basically allows us to chain base URLs like:

```js
const apiRouter = createServer('/api').router;
const v1 = apiRouter.base('/v1'); // => '/api/v1'
const v2 = apiRouter.base('/v2'); // => '/api/v2'

v1.base('/user'); // => '/api/v1/user'
```

## Types of changes
<!-- Put an `x` in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature

**If fixing bugs:**

- [x] Tests for the changes have been added.
- [x] Docs have been updated.

## Does this PR introduce a breaking change?

- [x] Yes (but the influence is limited)
- [ ] No
