### PR TITLE
Rename router.base() to router.scope()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -416,7 +416,7 @@ apiRouter.get('/greet', 'Hello new world');
 ### router.route()
 
 ```js
-router.route(path?): ScopedRouter
+router.route(path?): SubRouter
 ```
 
 | Param | Type | Description |

--- a/docs/api.md
+++ b/docs/api.md
@@ -225,7 +225,7 @@ console.log(server.router); // Router{}
 
 ## Router
 
-A new `Router` instance is constructed by <a href="#createserver" jump-to-id="createserver"><code>createServer()</code></a> function or <a href="#router-base" jump-to-id="router-base"><code>router.base()</code></a> method.
+A new `Router` instance is constructed by <a href="#createserver" jump-to-id="createserver"><code>createServer()</code></a> function or <a href="#router-scope" jump-to-id="router-scope"><code>router.scope()</code></a> method.
 
 In Service Mocker, we are using the [express style](http://expressjs.com/en/guide/routing.html) route paths via the [path-to-regexp](https://github.com/pillarjs/path-to-regexp) module. You can visit [express/routing](http://expressjs.com/en/guide/routing.html) for more routing guides.
 
@@ -354,48 +354,56 @@ With this router, you will get the following results:
 ❌  GET  https://a.com/whatever
 ```
 
-### router.base()
+### router.scope()
 
 ```js
-router.base(path?): Router
+router.scope(path?): Router
 ```
 
 | Param | Type | Description |
 | --- | :-: | --- |
-| `path` | string | The path prefix of the new router. |
+| `path` | string | The scope path of the new router. |
 
-This method creates a **new router** which will be mounted on the given `path`. You can regard the base paths as **a chain of path prefixes**.
+This method creates a **new router** which will be shrinked within the given `path`. The `path` acts like a prefix for routes:
 
 ```js
 // router.baseURL = 'http://localhost:3000'
 
-const apiRouter = router.base('/api');
+const apiRouter = router.scope('/api');
 
 console.log(apiRouter === router); // false
 console.log(apiRouter.baseURL); // http://localhost:3000/api
 
-// chain base paths
-const v1 = apiRouter.base('/v1');
+// GET /api/greet
+apiRouter.get('/greet', 'Hello new world!');
+```
+
+The `path` will be resolved against current router's `baseURL`:
+
+```js
+const { router } = createServer('/api');
+const v1 = router.scope('/v1');
 
 console.log(v1.baseURL); // http://localhost:3000/api/v1
 
+// GET /api/v1/users/:id
 v1.get('/users/:id', (req, res) => {
-  // matches /api/v1/users/:id
+  ...
 });
 ```
 
-<p class="danger">Unlike the <a href="#createserver" jump-to-id="createserver"><code>createServer()</code></a> method, the <code>path</code> here should always be a relative one:</p>
+<p class="danger">The <code>path</code> should always start with a leading slash <code>"/"</code>:</p>
 
 ```js
-router.base('/api'); // OK
-router.base('http://a.com/api'); // Error: not sharing same origin
+router.scope('/api'); // OK
+router.scope('http://a.com/api'); // TypeError: ...
 ```
 
-When the base URL of a router is specified, all routes will base on it:
+When the scope of a router is specified, all routes will base on it:
 
 ```js
 const { router } = createServer();
-const apiRouter = router.base('/api');
+const apiRouter = router.scope('/api');
 
 apiRouter.get('/greet', 'Hello new world');
 ```
@@ -457,14 +465,10 @@ The Request object is inherited from the [native Request object](https://develop
 The `req.baseURL` property is literally equivalent to <a href="#router-baseurl" jump-to-id="router-baseurl">`router.baseURL`</a> property of current router.
 
 ```js
-// assuming you are running on http://localhost:3000
-router.base('/api').get('/whatever', (req, res) => {
+// router.baseURL = http://localhost:3000
+router.scope('/api').get('/whatever', (req, res) => {
   console.log(req.baseURL); // 'http://localhost:3000/api'
   console.log(req.baseURL === router.baseURL); // true
-});
-
-router.base('https://a.com/api').get('/whatever', (req, res) => {
-  console.log(req.baseURL); // 'https://a.com/api'
 });
 ```
 
@@ -475,13 +479,21 @@ router.base('https://a.com/api').get('/whatever', (req, res) => {
 The `req.path` property contains the path part of the current request.
 
 ```js
-// GET /api/users/1
-router.base('/api').get('/users/:id', (req, res) => {
-  console.log(req.path); // '/user/1'
-});
+// router.baseURL = http://localhost:3000
 
-router.base('/').get('/api/users/:id', (req, res) => {
+// GET /api/users/1
+router.get('/api/users/:id', (req, res) => {
   console.log(req.path); // '/api/users/1'
+});
+```
+
+<p class="danger">The pathname of current <code>router.baseURL</code> will be stripped from <code>req.path</code>:</p>
+
+```js
+// GET /api/users/1
+router.scope('/api').get('/users/:id', (req, res) => {
+  console.log(req.path); // '/users/1'
+  console.log(new URL(req.url).pathname); // '/api/users/1'
 });
 ```
 
@@ -498,7 +510,7 @@ router.get('/users/:id', (req, res) => {
 });
 
 // GET /api/users/1/videos/1024
-router.base('api').get('/users/:userID/videos/:videoID', function (req, res) {
+router.scope('/api').get('/users/:userID/videos/:videoID', function (req, res) {
   res.send(req.params); // { userID: '1', videoID: '1024' }
 });
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -262,7 +262,7 @@ If the second argument is provided with a non-function value, then the value wil
 
 | Param | Type | Description |
 | --- | :-: | --- |
-| `path` | string &#124; RegExp | An [express style](http://expressjs.com/en/guide/routing.html) route path. |
+| `path` | string &#124; RegExp | An [express style](http://expressjs.com/en/guide/routing.html) route path pattern. |
 | `responseBody` | any | The body to be sent. This can be one of [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob), [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [Array](https://developer.mozilla.org/en-US/docs/Glossary/array), [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), and [Primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) except `Symbol`. |
 
 Call `router.METHOD()` method to intercept HTTP requests by matching the given path pattern. The `METHOD` refers to a HTTP method of the request, such as `GET`, `POST` and so on, in **lowercase**. Thus, the actual routing methods are `router.get()`, `router.post()`, etc. See the <a href="#routing-methods" jump-to-id="routing-methods">Routing methods</a> below for the complete list.
@@ -322,14 +322,14 @@ router.all(path, responseBody): this
 
 | Param | Type | Description |
 | --- | :-: | --- |
-| `path` | string &#124; RegExp | An [express style](http://expressjs.com/en/guide/routing.html) route path. |
+| `path` | string &#124; RegExp | An [express style](http://expressjs.com/en/guide/routing.html) route path pattern. |
 | `callback` | (req, res) => void | A Routing handler which will be executed when the route is matched. The `callback` function receives two parameters:<br> <ol><li>`req`: A <a href="#request" jump-to-id="request">`Request()`</a> object.</li><li>`res`: A <a href="#response" jump-to-id="response">`Response()`</a> object.</li></ol> |
 
 If the second argument is provided with a non-function value, then the value will be regarded as response body:
 
 | Param | Type | Description |
 | --- | :-: | --- |
-| `path` | string &#124; RegExp | An [express style](http://expressjs.com/en/guide/routing.html) route path. |
+| `path` | string &#124; RegExp | An [express style](http://expressjs.com/en/guide/routing.html) route path pattern. |
 | `responseBody` | any | The body to be sent. This can be one of [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob), [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [Array](https://developer.mozilla.org/en-US/docs/Glossary/array), [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), and [Primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) except `Symbol`. |
 
 This method like the <a href="#router-method" jump-to-id="router-method">`router.METHOD()`</a> method but for **all types of HTTP requests**.
@@ -421,9 +421,9 @@ router.route(path?): SubRouter
 
 | Param | Type | Description |
 | --- | :-: | --- |
-| `path` | string | The route path for this sub router. |
+| `path` | string &#124; RegExp | The route path pattern for this sub router. |
 
-`router.route()` method creates a sub router of which all route paths are bound with the given `path`. The sub router contains all routing methods from <a href="#router" jump-to-id="router">`Router`</a>, use this method to avoid duplicate route naming and thus typing errors:
+`router.route()` method creates a sub router of which all route paths are bound with the given `path` pattern. The sub router contains all routing methods from <a href="#router" jump-to-id="router">`Router`</a>, use this method to avoid duplicate route naming and thus typing errors:
 
 ```js
 router.route('/post/:id')

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -1,7 +1,13 @@
 import * as pathToRegExp from 'path-to-regexp';
 
+import {
+  debug,
+} from '../utils/';
+
 import { MockerRequest } from './request';
 import { MockerResponse } from './response';
+
+const routerLog = debug.scope('router');
 
 // bacic HTTP request methods in fetch standard, see
 // https://fetch.spec.whatwg.org/#concept-method
@@ -118,23 +124,26 @@ export class MockerRouter implements IMockerRouter {
   }
 
   /**
-   * Create a new router with the given path,
-   * the path will be resolved against current baseURL.
+   * Create a new router with the given path as scope.
    */
-  base(path: string = this.baseURL): MockerRouter {
-    // resolve relative paths to current base path
-    if (path[0] === '/') {
-      path = this._basePath + path;
+  scope(path?: string): MockerRouter {
+    // in case of falsy values
+    if (!path) {
+      path = '/';
     }
 
-    const url = new URL(path, this._origin);
-
-    if (url.origin !== this._origin) {
-      // tslint:disable-next-line max-line-length
-      throw new Error(`the given path (${path}) is not sharing the same origin with current baseURL (${this.baseURL})`);
+    if (path[0] !== '/') {
+      throw new TypeError(`the scope of router should be started with "/", got ${path}`);
     }
 
-    return new MockerRouter(url.href);
+    return new MockerRouter(this.baseURL + path);
+  }
+
+  /* istanbul ignore next */
+  base(path?: string): MockerRouter {
+    routerLog.warn('`router.base()` is deprecated, use `router.scope()` instead.');
+
+    return this.scope(path);
   }
 
   /**

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -42,7 +42,7 @@ export interface IRouterMatcher<T> {
   (path: RoutePath, responseBody: any): T;
 }
 
-export interface IScopedRouterMatcher<T> {
+export interface ISubRouterMatcher<T> {
   /**
    * Register a routing to current scope
    *
@@ -63,7 +63,7 @@ export interface IScopedRouterMatcher<T> {
 export interface IMockerRouter {
   readonly baseURL: string;
   scope(path?: string): IMockerRouter;
-  route(path: RoutePath): IScopedRouter;
+  route(path: RoutePath): ISubRouter;
 
   // routings
   all: IRouterMatcher<this>;
@@ -76,15 +76,15 @@ export interface IMockerRouter {
 }
 /* tslint:enable member-ordering */
 
-export interface IScopedRouter {
+export interface ISubRouter {
   // routings
-  all: IScopedRouterMatcher<this>;
-  get: IScopedRouterMatcher<this>;
-  post: IScopedRouterMatcher<this>;
-  put: IScopedRouterMatcher<this>;
-  head: IScopedRouterMatcher<this>;
-  delete: IScopedRouterMatcher<this>;
-  options: IScopedRouterMatcher<this>;
+  all: ISubRouterMatcher<this>;
+  get: ISubRouterMatcher<this>;
+  post: ISubRouterMatcher<this>;
+  put: ISubRouterMatcher<this>;
+  head: ISubRouterMatcher<this>;
+  delete: ISubRouterMatcher<this>;
+  options: ISubRouterMatcher<this>;
 }
 
 type RouteRule = {
@@ -150,8 +150,8 @@ export class MockerRouter implements IMockerRouter {
    * Create a scoped router with the given path as
    * route path for every routing method.
    */
-  route(path: RoutePath): ScopedRouter {
-    return new ScopedRouter(this, path);
+  route(path: RoutePath): SubRouter {
+    return new SubRouter(this, path);
   }
 
   /**
@@ -231,9 +231,9 @@ export class MockerRouter implements IMockerRouter {
   }
 }
 
-export interface ScopedRouter extends IScopedRouter {}
+export interface SubRouter extends ISubRouter {}
 
-export class ScopedRouter implements IScopedRouter {
+export class SubRouter implements ISubRouter {
   constructor(
     private _router: MockerRouter,
     private _path: RoutePath,
@@ -265,7 +265,7 @@ allMethods.forEach(method => {
 });
 
 allMethods.forEach(method => {
-  ScopedRouter.prototype[method] = function(callback) {
+  SubRouter.prototype[method] = function(callback) {
     return this.register(method, callback);
   };
 });

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -133,7 +133,7 @@ export class MockerRouter implements IMockerRouter {
     }
 
     if (path[0] !== '/') {
-      throw new TypeError(`the scope of router should be started with "/", got ${path}`);
+      throw new TypeError(`the scope of router should start with "/", got ${path}`);
     }
 
     return new MockerRouter(this.baseURL + path);

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -62,7 +62,7 @@ export interface IScopedRouterMatcher<T> {
 /* tslint:disable member-ordering */
 export interface IMockerRouter {
   readonly baseURL: string;
-  base(baseURL: string): IMockerRouter;
+  scope(path?: string): IMockerRouter;
   route(path: RoutePath): IScopedRouter;
 
   // routings

--- a/test/spec/server/request/req.baseURL.ts
+++ b/test/spec/server/request/req.baseURL.ts
@@ -11,7 +11,7 @@ export default function() {
   const { router } = createServer();
 
   describe('req.baseURL', () => {
-    describe('with `router.base()` unset', () => {
+    describe('with `router.scope()` unset', () => {
       it('should equal to local machine', async () => {
         const request = await requestToPromise();
 
@@ -20,13 +20,13 @@ export default function() {
       });
     });
 
-    describe('with `router.base(path)', () => {
-      it('should equal to the given relative path', async () => {
+    describe('with `router.scope(path)', () => {
+      it('should equal to the given scope path', async () => {
         const baseURL = '/api/v1';
         const path = uniquePath();
         let request: any;
 
-        router.base(baseURL).get(path, (req, res) => {
+        router.scope(baseURL).get(path, (req, res) => {
           request = req;
           res.end();
         });

--- a/test/spec/server/request/req.path.ts
+++ b/test/spec/server/request/req.path.ts
@@ -28,7 +28,7 @@ export default function() {
         const path = uniquePath();
         const baseURL = '/api/v1';
 
-        router.base(baseURL).get(path, (req, res) => {
+        router.scope(baseURL).get(path, (req, res) => {
           request = req;
           res.end();
         });

--- a/test/spec/server/router/router.method.ts
+++ b/test/spec/server/router/router.method.ts
@@ -71,7 +71,7 @@ export default function() {
   describe('when matching multiple rules', () => {
     it('should only invoke the first matched route', async () => {
       const path = uniquePath();
-      const rr = router.base();
+      const rr = router.scope();
 
       let id = 0;
 

--- a/test/spec/server/router/router.scope.ts
+++ b/test/spec/server/router/router.scope.ts
@@ -9,21 +9,21 @@ import {
 export default function() {
   const { router } = createServer();
 
-  describe('router.base(undefined)', () => {
-    it('should set to current baseURL when not given', () => {
-      const rr = router.base();
+  describe('router.scope(undefined)', () => {
+    it('should set to current baseURL', () => {
+      const rr = router.scope();
 
       expect(rr.baseURL).to.equal(router.baseURL);
     });
   });
 
-  describe('router.base(String)', () => {
+  describe('router.scope(String)', () => {
     it('should return a new Router', () => {
-      expect(router.base('/')).not.to.equal(router);
+      expect(router.scope('/')).not.to.equal(router);
     });
 
     it('should strip the trailing slash', () => {
-      const rr = router.base('/api/');
+      const rr = router.scope('/api/');
 
       expect(rr.baseURL).to.equal(router.baseURL + '/api');
     });
@@ -31,39 +31,39 @@ export default function() {
     it('should match baseURL from begining', async () => {
       const path = uniquePath();
 
-      router.base('/api').get('/greet' + path, 'Something is wrong');
-      router.base('/greet').get('/api' + path, 'Hello world');
+      router.scope('/api').get('/greet' + path, 'Something is wrong');
+      router.scope('/greet').get('/api' + path, 'Hello world');
 
       const { body } = await sendRequest('/greet/api' + path);
 
       expect(body).to.equal('Hello world');
     });
 
-    describe('with a relative path', () => {
+    describe('with a correct scope path', () => {
       it('should resolve to current origin', () => {
-        const rr = router.base('/whatever');
+        const rr = router.scope('/whatever');
 
         expect(rr.baseURL).to.equal(new URL('/whatever', location.href).href);
       });
 
       it('should resolve against current baseURL', () => {
-        const rr = router.base('/what').base('/ever');
+        const rr = router.scope('/what').scope('/ever');
 
         expect(new URL(rr.baseURL).pathname).to.equal('/what/ever');
       });
     });
 
-    describe('with an absolute path', () => {
-      it('should abort processing', () => {
+    describe('with an illegal path', () => {
+      it('should throw a TypeError', () => {
         let err: any;
 
         try {
-          router.base('http://a.com');
+          router.scope('http://a.com');
         } catch (e) {
           err = e;
         }
 
-        expect(err).to.exist;
+        expect(err).to.be.an.instanceof(TypeError);
       });
     });
   });


### PR DESCRIPTION
Rename `router.base()` method to `router.scope()`, as we've discussed in #23.

CC @VincentBel 