### PR TITLE
test(console): fix Edge 16 error

### DIFF
--- a/test/spec/misc/prefixed-console.js
+++ b/test/spec/misc/prefixed-console.js
@@ -4,17 +4,12 @@ import { PrefixedConsole } from 'service-mocker/utils';
 export default function () {
   describe('PrefixedConsole', () => {
     describe('inheritance', () => {
-      it('should inherit from `console` object', () => {
+      it('should support basic console logging functions', () => {
         const c = new PrefixedConsole();
 
-        for (let prop in console) {
-          // Accessing the `memory` property of `console` via prototype
-          // will throw an "Invalid calling object" error in Edge 16.
-          // see more at <https://github.com/service-mocker/service-mocker/pull/50>
-          if (prop !== 'memory') {
-            expect(c).to.have.property(prop);
-          }
-        }
+        ['log', 'info', 'warn', 'error'].forEach((prop) => {
+          expect(c).to.have.property(prop);
+        });
       });
     });
 

--- a/test/spec/misc/prefixed-console.js
+++ b/test/spec/misc/prefixed-console.js
@@ -8,7 +8,12 @@ export default function () {
         const c = new PrefixedConsole();
 
         for (let prop in console) {
-          expect(c).to.have.property(prop);
+          // Accessing the `memory` property of `console` via prototype
+          // will throw an "Invalid calling object" error in Edge 16.
+          // see more at <https://github.com/service-mocker/service-mocker/pull/50>
+          if (prop !== 'memory') {
+            expect(c).to.have.property(prop);
+          }
         }
       });
     });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Accessing the `memory` property of `console` via prototype will throw an "Invalid calling object" error in Edge 16.

![image](https://user-images.githubusercontent.com/6076919/37286404-cd25343c-263c-11e8-921b-8ad802b6cb30.png)

Sorry that I can't find any document on `console.memory`. Personally I guess the `memory` was introduced on new Edge version using by the [`console.takeHeapSnapshot()` API](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide/console/console-api#taking-heap-snapshots), and will deny access from outside.

And here is the debug info:

![image](https://user-images.githubusercontent.com/6076919/37286463-f506f5b2-263c-11e8-864f-ddf122470322.png)


## Types of changes
<!-- Put an `x` in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Fix tests

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
